### PR TITLE
Script provides inaccurate information to the user

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,7 +11,7 @@ fi
 #Stop the script if its started as root
 if [ "$(id -u)" -eq 0 ]; then
    echo "You shouldn't start EtherDraw as root!"
-   echo "Please type 'Etherpad Lite rocks my socks' if you still want to start it as root"
+   echo "Please type 'EtherDraw rocks my socks' if you still want to start it as root"
    read rocks
    if [ ! $rocks = "EtherDraw rocks my socks" ]
    then


### PR DESCRIPTION
Asks users to type "Etherpad Lite" but checks for "EtherDraw".