### PR TITLE
Remove trailing comma from last config line

### DIFF
--- a/settings.json.template
+++ b/settings.json.template
@@ -28,7 +28,7 @@
   */
 
   /* The default selected tool - 'pencil', 'brush', 'select' */
-  "tool": "brush",
+  "tool": "brush"
                  
   /* Example SSL Configuration
     "ssl" : {


### PR DESCRIPTION
The settings.json.template file has a trailing comma in it. This is likely because it shows an example configuration after this line, but this line is the last one that will be interpreted by the program in default configuration, so the comma should be removed.