### PR TITLE
take ip-address from settings json

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ if(settings.ssl){
     cert: fs.readFileSync(settings.ssl.cert)
   };
   var app = express(options);
-  var server = https.createServer(options, app).listen(settings.port);
+  var server = https.createServer(options, app).listen(settings.ip, settings.port);
 }else{
   var app = express();
   var server = app.listen(settings.port);
@@ -96,7 +96,7 @@ app.use("/static", express.static(__dirname + '/src/static'));
 var io = socket.listen(server);
 io.sockets.setMaxListeners(0);
 
-console.log("Access Etherdraw at http://127.0.0.1:"+settings.port);
+console.log("Access Etherdraw at http://"+settings.ip+":"+settings.port);
 
 // SOCKET IO
 io.sockets.on('connection', function (socket) {


### PR DESCRIPTION
Hi there, great etherpad-hero,

the ip-address in `server.js` was still hard-code. Minor change to take actually the one from `settings.json`.

Thanks,
Thomas