### PR TITLE
Clean of #canvasContainer and color picker position

### DIFF
--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -320,6 +320,19 @@ input[type=checkbox] {
   display: none;
   z-index: 500;
 }
+
+#canvasContainer{
+  position:absolute;
+  top:37px;
+  left:0px;
+  right:0px;
+  bottom:0px;
+  overflow: hidden;
+  background-repeat:no-repeat;
+  background-attachment: fixed;
+  background-position: 0px 37px;
+}
+
 @media screen and (max-width: 600px) { 
     .toolbar ul li.separator {
       display: none;
@@ -355,6 +368,9 @@ input[type=checkbox] {
     }
     #editorcontainer {
       margin-bottom: 33px
+    }
+    #canvasContainer {
+      bottom: 32px;
     }
     .toolbar ul.menu_right {
       background: #f7f7f7;
@@ -443,21 +459,10 @@ input[type=checkbox] {
   cursor:move;
 }
 
-#canvasContainer{
-  position:absolute;
-  top:0px;
-  left:0px;
-  right:0px;
-  bottom:0px;
-  background-repeat:no-repeat;
-  background-attachment: fixed;
-  background-position: 0px 37px;
-}
-
 #myCanvas{
   position:absolute;
   cursor:hand;
-  top:37px;
+  top:0px;
   left:0px;
   right:0px;
   bottom:0px;

--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -12,6 +12,54 @@ function pickColor(color) {
   update_active_color();
 }
 
+/**
+ * Position picker next to cursor in the bounds of the canvas container
+ *
+ * @param cursor {Point} Cursor position relative to the page
+ */
+function positionPickerInCanvas(cursor) {
+  var picker = $('#mycolorpicker');
+  
+  // Determine best place for color picker so it isn't off the screen
+  var pickerSize = new Point(picker.width(), picker.height());
+  var windowSize = new Point($(window).width(), $(window).height());
+  var spacer = new Point(10, 0);
+
+  var brSpace = windowSize - spacer - cursor;
+  var tlSpace = cursor - spacer;
+
+  var newPos = new Point();
+
+  // Choose sides based on page size
+  if (tlSpace.x > pickerSize.x) {
+    // Plus a magic number...?
+    newPos.x = cursor.x - (pickerSize.x + 20 + spacer.x);
+  } else if (brSpace.x > pickerSize.x) {
+    newPos.x = cursor.x + spacer.x;
+  }
+  
+  // Get the canvasContainer's position so we can make sure the picker
+  // doesn't go outside of the canvasContainer (to keep it pretty)
+  var minY = 10;
+  // Buffer so we don't get too close to the bottom cause scroll bars
+  var bBuffer = Math.max(50, (windowSize.y - ($('#canvasContainer').position().top 
+      + $('#canvasContainer').height())) + 70);
+
+  // Favour having the picker in the middle of the cursor
+  if (tlSpace.y > ((pickerSize.y / 2) + minY) && brSpace.y > ((pickerSize.y / 2) + bBuffer)) {
+    newPos.y = cursor.y - (pickerSize.y / 2);
+  } else if (tlSpace.y < ((pickerSize.y / 2) + minY) && brSpace.y > (tlSpace.y - (pickerSize.y + minY))) {
+    newPos.y = minY;
+  } else if (brSpace.y < ((pickerSize.y / 2) + bBuffer) && tlSpace.y > (brSpace.y - (pickerSize.y + bBuffer))) {
+    newPos.y = windowSize.y - (pickerSize.y + bBuffer);
+  }
+  
+  $('#mycolorpicker').css({
+    "left": newPos.x,
+    "top": newPos.y
+  }); // make it in the smae position
+}
+
 /*http://stackoverflow.com/questions/5623838/rgb-to-hex-and-hex-to-rgb*/
 function hexToRgb(hex) {
   var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -142,7 +190,9 @@ update_active_color();
 
 
 $('#colorToggle').on('click', function() {
-  $('#mycolorpicker').toggle();
+  if ($('#mycolorpicker').toggle().is(':visible')) {
+    positionPickerInCanvas(new Point(event.pageX, event.pageY));
+  }
 });
 
 $('#clearImage').click(function() {
@@ -176,18 +226,27 @@ function onMouseDown(event) {
   if (event.event.button == 1 || event.event.button == 2) {
     return;
   }
+  
+  // Hide color picker if it is visible already
+  var picker = $('#mycolorpicker');
+  if (picker.is(':visible')) {
+    picker.toggle(); // show the color picker
+  }
 
   mouseTimer = 0;
   mouseHeld = setInterval(function() { // is the mouse being held and not dragged?
     mouseTimer++;
-    if (mouseTimer > 5) {
+    if (mouseTimer > 3) {
       mouseTimer = 0;
       clearInterval(mouseHeld);
-      $('#mycolorpicker').toggle(); // show the color picker
-      $('#mycolorpicker').css({
-        "left": event.event.pageX - 250,
-        "top": event.event.pageY - 100
-      }); // make it in the smae position
+      var picker = $('#mycolorpicker');
+      picker.toggle(); // show the color picker
+      if (picker.is(':visible')) {
+        // Mad hackery to get round issues with event.point
+        var targetPos = $(event.event.target).position();
+        var point = event.point + new Point(targetPos.left, targetPos.top);
+        positionPickerInCanvas(point);
+      }
     }
   }, 100);
 
@@ -503,8 +562,8 @@ $color.on('click', function() {
 
 });
 
-$('#pickerSwatch').on('click', function() {
-  $('#myColorPicker').fadeToggle();
+$('#pickerSwatch').on('click', function(event) {
+  $('#mycolorpicker').toggle();
 });
 $('#settingslink').on('click', function() {
   $('#settings').fadeToggle();


### PR DESCRIPTION
I tidied up the CSS around the #canvasContainer so that it doesn't overlap the toolbars and hides any excess canvas (handy for my canvas pan implementation https://github.com/theelectricwiz/draw/commit/5d93828d4819bcb743b31b94dadeac7f55be6a23). I also made it so it tries to keep the color picker on screen when you show it by holding button 0 down and so the picker is position when you click on the picker button.