### PR TITLE
Canvas Panning and Scaling tests **and modifier key changed**

### DIFF
--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
   });
 
   $('#myCanvas').bind('wheel', function(event) {
-		// Find the scroll delta
+    // Find the scroll delta
     var delta;
 
     if (event.originalEvent) {
@@ -484,7 +484,7 @@ function onMouseDrag(event) {
     // Add the bad delta to the delta make sure we won't go into the -ves
     delta -= badDelta;
 
-		var startBounds = view.bounds;
+    var startBounds = view.bounds;
   
     // Pretty scroll
     view.scrollBy(delta);

--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -369,7 +369,7 @@ function onMouseDown(event) {
   // Pan - Middle click, click+shift or two finger touch for canvas moving
   // Will also handle scaling using pinch gestures
   if (event.event.button == 1 
-      || (event.event.button == 0 && event.event.shiftKey)
+      || (event.event.button == 0 && event.event.ctrlKey)
       || (event.event.touches && event.event.touches.length == 2)) {
     previousPoint = getEventPoint(event.event, 'client');
     var canvas = $('#myCanvas');
@@ -468,7 +468,7 @@ function onMouseDrag(event) {
    * canvas moving and zooming if fingers are involved
    */
   if (event.event.button == 1 
-      || (event.event.button == 0 && event.event.shiftKey)
+      || (event.event.button == 0 && event.event.ctrlKey)
       || (event.event.touches && event.event.touches.length == 2)) {
     // Calculate our own delta as the event delta is relative to the canvas
     var point = getEventPoint(event.event, 'client');
@@ -585,7 +585,7 @@ function onMouseUp(event) {
 
   // Pan - Middle click, click+shift or two finger touch for canvas moving
   if (event.event.button == 1 
-      || (event.event.button == 0 && event.event.shiftKey)
+      || (event.event.button == 0 && event.event.ctrlKey)
       || (event.event.touches && fingers == 2)) {
     $('#myCanvas').css('cursor', 'pointer');
     return;
@@ -761,9 +761,6 @@ $('#myCanvas').bind('drop', function(e) {
 });
 
 //@todo Find why view has no on function view.on('resize', updateCoordinates);
-
-
-
 
 // --------------------------------- 
 // CONTROLS EVENTS

--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
   });
 
   $('#myCanvas').bind('wheel', function(event) {
-    // Find the scroll delta
+		// Find the scroll delta
     var delta;
 
     if (event.originalEvent) {
@@ -483,6 +483,8 @@ function onMouseDrag(event) {
 
     // Add the bad delta to the delta make sure we won't go into the -ves
     delta -= badDelta;
+
+		var startBounds = view.bounds;
   
     // Pretty scroll
     view.scrollBy(delta);

--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -337,6 +337,7 @@ var paper_object_count = 0;
 var activeTool = "draw";
 var mouseTimer = 0; // used for getting if the mouse is being held down but not dragged IE when bringin up color picker
 var mouseHeld; // global timer for if mouse is held.
+var path; // Used to store the path currently being drawn
 
 var fingers; // Used for tracking how many finger have been used in the last event
 var previousPoint; // Used to track the previous event point for panning
@@ -507,7 +508,7 @@ function onMouseDrag(event) {
     return;
   }
 
-  if (path && (activeTool == "draw" || activeTool == "pencil")) {
+  if ((activeTool == "draw" || activeTool == "pencil") && path) {
     var step = event.delta / 2;
     step.angle += 90;
     if (activeTool == "draw") {
@@ -593,7 +594,7 @@ function onMouseUp(event) {
   clearInterval(mouseHeld);
   mouseHeld = undefined;
 
-  if (path && (activeTool == "draw" || activeTool == "pencil")) {
+  if ((activeTool == "draw" || activeTool == "pencil") && path) {
     // Close the users path
     path.add(event.point);
     path.closed = true;

--- a/src/static/js/draw.js
+++ b/src/static/js/draw.js
@@ -1053,9 +1053,6 @@ socket.on('image:add', function(artist, data, position, name) {
   }
 });
 
-
-console.log(view);
-
 // --------------------------------- 
 // SOCKET.IO EVENT FUNCTIONS
 

--- a/tests/frontend/specs/scale_pan.js
+++ b/tests/frontend/specs/scale_pan.js
@@ -1,0 +1,158 @@
+describe("Scale and Pan", function(){
+
+  var oldPadName,
+      padName,
+      path,
+      reloaded = false;
+
+	var panMethods = {
+		'middle click and drag': {
+			button: 1
+		},
+		'<CTRL> click and drag': {
+			button: 0,
+			ctrlKey: true
+		}
+	};
+
+  it("creates a pad", function(done) {
+    padName = helper.newPad(done);
+    this.timeout(60000);
+  });
+  
+  it("draw a path", function(done) {
+    var chrome$ = helper.padChrome$;
+    var paper = window.frames[0].paper;
+
+    // Mouse clicks and drags to create path
+    var canvas = chrome$("#myCanvas");
+    canvas.simulate('drag', {dx: 100, dy: 50});
+
+    done();
+  });
+ 
+ 	describe('Panning', function() {
+		var m;
+
+		for (m in panMethods) {
+			it(m + " pans linearly", (function(m) { return function(done) {
+				this.timeout(5000);
+
+				var chrome$ = helper.padChrome$;
+				var paper = window.frames[0].paper;
+
+				// Mouse clicks and drags to create path
+				var canvas = chrome$("#myCanvas");
+				canvas.simulate('drag', {
+					dx: -100, dy: -50,
+					eventOptions: panMethods[m]
+				});
+
+				var view = paper.project.view;
+				var bounds = view.bounds;
+				expect(bounds.x).to.be(100);
+				expect(bounds.y).to.be(50);
+				done();
+			}; })(m));
+
+			it(m + " stops at 0,0", (function(m) { return function(done) {
+				this.timeout(5000);
+
+				var chrome$ = helper.padChrome$;
+				var paper = window.frames[0].paper;
+
+				// Mouse clicks and drags to create path
+				var canvas = chrome$("#myCanvas");
+				canvas.simulate('drag', {
+					dx: 200, dy: 100,
+					eventOptions: panMethods[m]
+				});
+				var view = paper.project.view;
+				var bounds = view.bounds;
+				expect(bounds.x).to.be(0);
+				expect(bounds.y).to.be(0);
+				done();
+			}; })(m));
+		}
+	});
+
+	var scrollTypes = {
+		'pixel scroll': {
+			eventOptions : {
+				deltaX: -50,
+				deltaY: 0,
+				deltaMode: 0
+			},
+			scaleDiff: 50 * 0.002
+		},
+		'line scroll': {
+			eventOptions : {
+				deltaX: 5,
+				deltaY: 0,
+				deltaMode: 1
+			},
+			scaleDiff: -5 * 0.02
+		},
+		'page scroll': {
+			eventOptions : {
+				deltaX: -1,
+				deltaY: 0,
+				deltaMode: 2
+			},
+			scaleDiff: 1 * 0.1
+		}
+	};
+
+	describe('Scaling', function() {
+		var s;
+
+		for (s in scrollTypes) {
+			it(s + ' should scale', (function(s) { return function(done) {
+				this.timeout(5000);
+
+				var chrome$ = helper.padChrome$;
+				var paper = window.frames[0].paper;
+				var view = paper.project.view;
+				var oldScale = view.zoom;
+
+				// Mouse clicks and drags to create path
+				var canvas = chrome$("#myCanvas");
+				canvas.simulate('wheel', scrollTypes[s].eventOptions);
+
+				var newScale = view.zoom;
+
+				expect(newScale).to.be(oldScale + scrollTypes[s].scaleDiff);
+				done();
+			}; })(s));
+		}
+	});
+
+	describe('Scaled panning', function() {
+		it('should pan evenly when zoomed in', function(done) {
+				var chrome$ = helper.padChrome$;
+				var paper = window.frames[0].paper;
+				var view = paper.project.view;
+				view.zoom = 2;
+				view.draw();
+				
+				var startBounds = view.bounds;
+
+				// Mouse clicks and drags to create path
+				var canvas = chrome$("#myCanvas");
+
+				canvas.simulate('drag', {
+					dx: -200, dy: -100,
+					eventOptions: {
+						button: 1
+					}
+				});
+				
+				var bounds = view.bounds;
+				
+				expect(bounds.x).to.be(startBounds.x + (200/2));
+				expect(bounds.y).to.be(startBounds.y + (100/2));
+				done();
+		
+		});
+	});
+});


### PR DESCRIPTION
I have implemented tests for the mouse side of scrolling and panning. To do this, I had to modify jquery.simulate.js so it could handle wheel events and be able to be passed options for drag events.

**I have changed the modifier key for left click panning to CTRL**. This was because it was stuffing the way the selection tool works at the moment.