### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=0.12.x"
   },
+  "license": "Apache-2.0",
   "dependencies": {
     "express": "~3.5.1",
     "socket.io": "~1.0.0",


### PR DESCRIPTION
This prevents such warnings:
```
npm WARN etherdraw@0.1.2 No license field.
```