### PR TITLE
Ensure settings are sent for new drawings

### DIFF
--- a/server.js
+++ b/server.js
@@ -184,6 +184,9 @@ function subscribe(socket, data) {
   //  clearTimeout(closeTimer[room]);
   // }
 
+  // Send settings
+  socket.emit('settings', clientSettings);
+
   // Create Paperjs instance for this room if it doesn't exist
   var project = projects.projects[room];
   if (!project) {
@@ -217,7 +220,6 @@ function loadFromMemory(room, socket) {
   socket.emit('loading:start');
   var value = project.exportJSON();
   socket.emit('project:load', {project: value});
-  socket.emit('settings', clientSettings);
   socket.emit('loading:end');
 }
 


### PR DESCRIPTION
Not a big issue at the moment, but if more settings are going to be sent, then they should always been sent rather than for just existing drawings